### PR TITLE
Improve handling of missing DICOM tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "rx-repack"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
  "fs-err",
  "glob",
  "hashbrown",
+ "itertools",
  "pathdiff",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "rx-repack"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fs-err = "2.9.0"
 camino = { version = "1.1.6", features = ["serde1"] }
 hashbrown = { version = "0.14.0", features = ["serde"] }
 thiserror = "1.0.43"
+itertools = "0.11.0"
 
 # https://github.com/johnthagen/min-sized-rust
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rx-repack"
 description = "Rust re-write of px-repack"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rx-repack"
 description = "Rust re-write of px-repack"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/dicom_data.rs
+++ b/src/dicom_data.rs
@@ -1,0 +1,115 @@
+use dicom::core::value::{CastValueError, ConvertValueError};
+use dicom::core::DataDictionary;
+use dicom::dictionary_std::{tags, StandardDataDictionary};
+use dicom::object::{DefaultDicomObject, Tag};
+use hashbrown::HashMap;
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+/// DICOM tag data reader.
+///
+/// Reading of DICOM tag data is fallible. If any errors occurs while trying to read data,
+/// some default value is returned instead, and the error is recorded in `errors`.
+pub(crate) struct TagExtractor<'a> {
+    pub dcm: &'a DefaultDicomObject,
+    pub errors: RefCell<HashMap<Tag, DicomTagError>>,
+}
+
+/// Error reading a DICOM tag's value.
+#[derive(thiserror::Error, Debug)]
+pub enum DicomTagError {
+    #[error(transparent)]
+    Access(#[from] dicom::object::AccessError),
+    #[error(transparent)]
+    CastValue(#[from] CastValueError),
+    #[error(transparent)]
+    ConvertValue(#[from] ConvertValueError),
+}
+
+/// DICOM elements which a [PypxPath] is comprised of.
+///
+/// These DICOM elements _must_ be present and valid for `pypx`.
+#[allow(non_snake_case)]
+pub(crate) struct CommonElements<'a> {
+    // these are all part of the path name.
+    pub InstanceNumber: &'a str,
+    pub SOPInstanceUID: &'a str,
+    pub PatientID: &'a str,
+    pub PatientName: &'a str,
+    pub PatientBirthDate: &'a str,
+    pub StudyDescription: &'a str,
+    pub AccessionNumnber: &'a str,
+    pub StudyDate: &'a str,
+    pub SeriesNumber: i32, // SeriesNumber is of the "Integer String" (IS) type
+    pub SeriesDescription: &'a str,
+
+    // these are not part of the path name, but used in the log path names.
+    pub StudyInstanceUID: String,
+    pub SeriesInstanceUID: String,
+}
+
+impl<'a> TagExtractor<'a> {
+    pub fn new(dcm: &'a DefaultDicomObject) -> Self {
+        Self {
+            dcm,
+            errors: RefCell::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, tag: Tag) -> Cow<str> {
+        self.dcm
+            .element(tag)
+            .map_err(DicomTagError::from)
+            .and_then(|ele| ele.to_str().map_err(DicomTagError::from))
+            .unwrap_or_else(|e| {
+                self.errors.borrow_mut().insert(tag, e);
+                "".into()
+            })
+    }
+}
+
+impl<'a> TryFrom<&'a DefaultDicomObject> for CommonElements<'a> {
+    type Error = DicomTagError;
+    fn try_from(dcm: &'a DefaultDicomObject) -> Result<Self, Self::Error> {
+        // NOTE: the implementation here is optimized based on implementation details of dicom-rs v0.5.4.
+        // - dcm.element(...)?.string() produces a reference to the data w/o cloning nor parsing
+        // - dcm.element is more efficient than dcm.element_by_name, since the latter does a map lookup
+        let data = Self {
+            InstanceNumber: tt(dcm, tags::INSTANCE_NUMBER)?,
+            SOPInstanceUID: tt(dcm, tags::SOP_INSTANCE_UID)?,
+            PatientID: tt(dcm, tags::PATIENT_ID)?,
+            PatientName: tt(dcm, tags::PATIENT_NAME)?,
+            PatientBirthDate: tt(dcm, tags::PATIENT_BIRTH_DATE)?,
+            StudyDescription: tt(dcm, tags::STUDY_DESCRIPTION)?,
+            AccessionNumnber: tt(dcm, tags::ACCESSION_NUMBER)?,
+            StudyDate: tt(dcm, tags::STUDY_DATE)?,
+            SeriesNumber: dcm
+                .element(tags::SERIES_NUMBER)
+                .map_err(Self::Error::from)
+                .and_then(|ele| ele.value().to_int::<i32>().map_err(Self::Error::from))?,
+            SeriesDescription: tt(dcm, tags::SERIES_DESCRIPTION)?,
+            StudyInstanceUID: tts(dcm, tags::STUDY_INSTANCE_UID)?,
+            SeriesInstanceUID: tts(dcm, tags::SERIES_INSTANCE_UID)?,
+        };
+        Ok(data)
+    }
+}
+
+/// Get the `&str` to a DICOM object.
+///
+/// I tried to make this helper function low-cost.
+fn tt(dcm: &DefaultDicomObject, tag: Tag) -> Result<&str, DicomTagError> {
+    // TODO make this a method, and maybe we should call replace('\0', "")
+    dcm.element(tag)
+        .map_err(DicomTagError::from)
+        .and_then(|e| e.string().map(|s| s.trim()).map_err(DicomTagError::from))
+}
+
+fn tts(dcm: &DefaultDicomObject, tag: Tag) -> Result<String, DicomTagError> {
+    tt(dcm, tag).map(|s| s.replace('\0', ""))
+}
+
+pub(crate) fn name_of(tag: Tag) -> Option<&'static str> {
+    // WHY SAG-anon has a DICOM tag (0019,0010)?
+    StandardDataDictionary.by_tag(tag).map(|e| e.alias)
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 /// Error decoding a DICOM tag's value.
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum DicomElementSerializationError {
+pub(crate) enum ElementSerializationError {
     #[error("Unknown tag: {0}")]
     UnknownTagError(dicom::core::Tag),
     #[error("{0} should not be serialized.")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,20 +1,3 @@
-use std::num::ParseIntError;
-
-/// Error reading a DICOM tag's value.
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum DicomTagReadError {
-    #[error(transparent)]
-    ParseIntError(#[from] ParseIntError),
-    #[error(transparent)]
-    Access(#[from] dicom::object::AccessError),
-    #[error("{tag:?} tag value is not a string")]
-    NotString {
-        #[source]
-        error: dicom::core::value::CastValueError,
-        tag: dicom::core::Tag,
-    },
-}
-
 /// Error decoding a DICOM tag's value.
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum DicomElementSerializationError {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,24 +1,17 @@
-use crate::errors::DicomTagReadError;
-use dicom::core::Tag;
-use dicom::object::DefaultDicomObject;
+use dicom::core::value::{CastValueError, ValueType};
+use dicom::core::{DataDictionary, Tag};
+use dicom::object::{DefaultDicomObject, StandardDataDictionary};
 use regex::Regex;
 use std::sync::OnceLock;
 
-/// Get the `&str` to a DICOM object.
-///
-/// I tried to make this helper function low-cost.
-pub(crate) fn tt(dcm: &DefaultDicomObject, tag: Tag) -> Result<&str, DicomTagReadError> {
-    // TODO make this a method, and maybe we should call replace('\0', "")
-    dcm.element(tag).map_err(|e| e.into()).and_then(|e| {
-        e.string()
-            .map(|s| s.trim())
-            .map_err(|error| DicomTagReadError::NotString { error, tag })
-    })
-}
-
-pub(crate) fn tts(dcm: &DefaultDicomObject, tag: Tag) -> Result<String, DicomTagReadError> {
-    tt(dcm, tag).map(|s| s.replace('\0', ""))
-}
+// fn empty2str(error: CastValueError) -> Result<&'static str, CastValueError> {
+//     if matches!(error.got, ValueType::Empty) {
+//         Ok("")
+//     } else {
+//         Err(error)
+//     }
+// }
+//
 
 /// Replace disallowed characters with "_".
 /// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/repack.py#L424

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,17 +1,5 @@
-use dicom::core::value::{CastValueError, ValueType};
-use dicom::core::{DataDictionary, Tag};
-use dicom::object::{DefaultDicomObject, StandardDataDictionary};
 use regex::Regex;
 use std::sync::OnceLock;
-
-// fn empty2str(error: CastValueError) -> Result<&'static str, CastValueError> {
-//     if matches!(error.got, ValueType::Empty) {
-//         Ok("")
-//     } else {
-//         Err(error)
-//     }
-// }
-//
 
 /// Replace disallowed characters with "_".
 /// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/repack.py#L424

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+mod dicom_data;
 mod errors;
 mod helpers;
 mod log_models;
 mod log_write;
+mod ndjson_log;
 mod pack_path;
 mod repack;
 
+pub use ndjson_log::json_message;
 pub use repack::repack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod log_write;
 mod ndjson_log;
 mod pack_path;
 mod repack;
+mod serialize_seriesmeta;
 
 pub use ndjson_log::json_message;
 pub use repack::repack;

--- a/src/log_models.rs
+++ b/src/log_models.rs
@@ -84,7 +84,7 @@ pub(crate) struct InstanceData<'a> {
     StudyInstanceUID: &'a str,
     SeriesInstanceUID: &'a str,
     SeriesDescription: Cow<'a, str>,
-    SeriesNumber: u32,
+    SeriesNumber: i32,
     SeriesDate: Cow<'a, str>,
     Modality: Cow<'a, str>,
     outputFile: &'a str,
@@ -108,7 +108,7 @@ impl<'a> InstanceData<'a> {
             StudyInstanceUID: &e.StudyInstanceUID,
             SeriesInstanceUID: &e.SeriesInstanceUID,
             SeriesDescription: d.get(tags::SERIES_DESCRIPTION),
-            SeriesNumber: d.get(tags::SERIES_NUMBER).parse().unwrap(), // FIXME
+            SeriesNumber: d.get_i32(tags::SERIES_NUMBER),
             SeriesDate: d.get(tags::SERIES_DATE),
             Modality: d.get(tags::MODALITY),
             outputFile,

--- a/src/log_models.rs
+++ b/src/log_models.rs
@@ -1,15 +1,7 @@
 //! Models of what gets written to `/home/dicom/log`.
 #![allow(non_snake_case)]
-
-use crate::errors::{DicomElementSerializationError, DicomTagReadError};
-use crate::helpers::tt;
-use crate::pack_path::PypxPathElements;
-use dicom::core::header::Header;
-use dicom::core::value::{CastValueError, Value};
-use dicom::core::{DataDictionary, Tag, VR};
-use dicom::dictionary_std::{tags, StandardDataDictionary};
-use dicom::object::mem::InMemElement;
-use dicom::object::DefaultDicomObject;
+use crate::dicom_data::{CommonElements, TagExtractor};
+use dicom::dictionary_std::tags;
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -25,239 +17,228 @@ pub(crate) struct PatientData<'a> {
 }
 
 impl<'a> PatientData<'a> {
-    pub fn new(
-        d: &'a DefaultDicomObject,
-        e: &'a PypxPathElements,
-    ) -> Result<Self, DicomTagReadError> {
-        {
-            let name = tt(d, tags::PATIENT_NAME)?;
-            let age = tt(d, tags::PATIENT_AGE)?;
-            let sex = tt(d, tags::PATIENT_SEX)?;
-            let patient = Self {
-                PatientID: Cow::Borrowed(e.PatientID),
-                PatientName: Cow::Borrowed(name),
-                PatientAge: Cow::Borrowed(age),
-                PatientSex: Cow::Borrowed(sex),
-                PatientBirthDate: Cow::Borrowed(e.PatientBirthDate),
-                StudyList: HashSet::new(),
-            };
-            Ok(patient)
+    pub fn new(d: &'a TagExtractor, e: &'a CommonElements) -> Self {
+        let PatientName = d.get(tags::PATIENT_NAME);
+        let PatientAge = d.get(tags::PATIENT_AGE);
+        let PatientSex = d.get(tags::PATIENT_SEX);
+        Self {
+            PatientID: Cow::Borrowed(e.PatientID),
+            PatientName,
+            PatientAge,
+            PatientSex,
+            PatientBirthDate: Cow::Borrowed(e.PatientBirthDate),
+            StudyList: HashSet::new(),
         }
     }
 }
-
-#[derive(Debug, Serialize)]
-pub(crate) struct StudyDataMeta<'a> {
-    PatientID: &'a str,
-    StudyDescription: &'a str,
-    StudyDate: &'a str,
-    StudyInstanceUID: &'a str,
-    PerformedStationAETitle: &'a str,
-}
-
-impl<'a> StudyDataMeta<'a> {
-    pub fn new(
-        d: &'a DefaultDicomObject,
-        e: &'a PypxPathElements,
-    ) -> Result<Self, DicomTagReadError> {
-        let data = Self {
-            PatientID: e.PatientID,
-            StudyDescription: e.StudyDescription,
-            StudyDate: e.StudyDate,
-            StudyInstanceUID: &e.StudyInstanceUID,
-            PerformedStationAETitle: tt(d, tags::PERFORMED_STATION_AE_TITLE).unwrap_or(""),
-        };
-        Ok(data)
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct StudyDataSeriesMeta<'a> {
-    SeriesInstanceUID: String,
-    SeriesBaseDir: String,
-    DICOM: HashMap<String, ValueAndLabel<'a>>,
-}
-
-impl<'a> StudyDataSeriesMeta<'a> {
-    pub fn new(
-        SeriesInstanceUID: String,
-        SeriesBaseDir: String,
-        dcm: &'a DefaultDicomObject,
-    ) -> Result<StudyDataSeriesMeta, CastValueError> {
-        let DICOM = dcm
-            .iter()
-            .map(ValueAndLabel::try_from)
-            .filter_map(|r| r.ok())
-            .map(|v| (v.label.to_string(), v))
-            .collect::<HashMap<String, ValueAndLabel>>();
-        Ok(Self {
-            SeriesInstanceUID,
-            SeriesBaseDir,
-            DICOM,
-        })
-    }
-}
-
-impl TryFrom<&InMemElement> for ValueAndLabel<'_> {
-    type Error = DicomElementSerializationError;
-    fn try_from(ele: &InMemElement) -> Result<Self, Self::Error> {
-        let tag = ele.tag();
-        if tag == tags::PIXEL_DATA {
-            return Err(DicomElementSerializationError::Excluded(tag));
-        }
-        let label =
-            name_of(tag).ok_or_else(|| DicomElementSerializationError::UnknownTagError(tag))?;
-        if matches!(ele.value(), Value::PixelSequence { .. }) {
-            return Err(DicomElementSerializationError::Excluded(tag));
-        }
-
-        let value = if INTEGER_VR.contains(&ele.vr()) {
-            // e.g. AcquisitionMatrix
-            serialize_loint(ele)
-        } else if ele.vr() == VR::DS {
-            // e.g. PixelSpacing, ImageOrientationPatient
-            serialize_lonum(ele)
-        } else {
-            serialize_lostr(ele)
-        }?;
-        Ok(Self { label, value })
-    }
-}
-
-const INTEGER_VR: [VR; 3] = [VR::US, VR::UL, VR::UV];
-
-fn serialize_loint(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-    if let Ok(v) = ele.to_multi_int::<i64>() {
-        let s = serialize_first_or_as_list(v)?;
-        Ok(s)
-    } else {
-        let s = serialize_lostr(ele)?;
-        eprintln!("WARNING: Could not serialize {} as list of int", &s);
-        Ok(s)
-    }
-}
-
-fn serialize_lonum(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-    if let Ok(v) = ele.to_multi_float64() {
-        let s = serialize_first_or_as_list(v)?;
-        Ok(s)
-    } else {
-        let s = serialize_lostr(ele)?;
-        eprintln!("WARNING: Could not serialize {} as list of float", &s);
-        Ok(s)
-    }
-}
-
-fn serialize_lostr(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-    let mut values = ele.to_multi_str()?.to_vec();
-    let value = if values.len() == 1 {
-        values.swap_remove(0)
-    } else {
-        serde_json::to_string(&values)?
-    };
-    Ok(value)
-}
-
-fn serialize_first_or_as_list<T: Serialize>(v: Vec<T>) -> Result<String, serde_json::Error> {
-    if v.len() == 1 {
-        serde_json::to_string(&v[0])
-    } else {
-        serde_json::to_string(&v)
-    }
-}
-
-fn name_of(tag: Tag) -> Option<&'static str> {
-    // WHY SAG-anon has a DICOM tag (0019,0010)?
-    StandardDataDictionary.by_tag(tag).map(|e| e.alias)
-}
-
-#[derive(Debug, Serialize)]
-struct ValueAndLabel<'a> {
-    value: String,
-    label: &'a str,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct SeriesDataMeta<'a> {
-    PatientID: &'a str,
-    StudyInstanceUID: &'a str,
-    SeriesInstanceUID: &'a str,
-    SeriesDescription: &'a str,
-    SeriesNumber: u32,
-    SeriesDate: &'a str,
-    Modality: &'a str,
-}
-
-impl<'a> SeriesDataMeta<'a> {
-    pub fn new(
-        d: &'a DefaultDicomObject,
-        e: &'a PypxPathElements,
-    ) -> Result<Self, DicomTagReadError> {
-        let data = Self {
-            PatientID: e.PatientID,
-            StudyInstanceUID: &e.StudyInstanceUID,
-            SeriesInstanceUID: &e.SeriesInstanceUID,
-            SeriesDescription: e.SeriesDescription,
-            SeriesNumber: e.SeriesNumber,
-            SeriesDate: e.StudyDate,
-            Modality: tt(d, tags::MODALITY)?,
-        };
-        Ok(data)
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct InstanceData<'a> {
-    PatientID: &'a str,
-    StudyInstanceUID: &'a str,
-    SeriesInstanceUID: &'a str,
-    SeriesDescription: &'a str,
-    SeriesNumber: u32,
-    SeriesDate: &'a str,
-    Modality: &'a str,
-    outputFile: &'a str,
-    // TODO we don't include imageObj because I don't think it's used anywhwere.
-    // Trying to get this information is annoying.
-    imageObj: HashMap<String, FileStat>,
-}
-
-impl<'a> InstanceData<'a> {
-    pub fn new(
-        d: &'a DefaultDicomObject,
-        e: &'a PypxPathElements,
-        outputFile: &'a str,
-        FSlocation: String,
-    ) -> Result<Self, DicomTagReadError> {
-        let imageObj = [(outputFile.to_string(), FileStat { FSlocation })]
-            .into_iter()
-            .collect();
-        let data = Self {
-            PatientID: e.PatientID,
-            StudyInstanceUID: tt(d, tags::STUDY_INSTANCE_UID)?,
-            SeriesInstanceUID: tt(d, tags::SERIES_INSTANCE_UID)?,
-            SeriesDescription: tt(d, tags::SERIES_DESCRIPTION)?,
-            SeriesNumber: tt(d, tags::SERIES_NUMBER)?.parse()?,
-            SeriesDate: tt(d, tags::SERIES_DATE)?,
-            Modality: tt(d, tags::MODALITY)?,
-            outputFile,
-            imageObj,
-        };
-        Ok(data)
-    }
-}
-
-/// File's stat metadata.
-/// Not complete.
-/// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/smdb.py#L1306-L1317
-#[derive(Debug, Serialize)]
-struct FileStat {
-    /// Important! Checked by smdb.py to count how many files are packed so far.
-    FSlocation: String,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct SeriesPack {
-    pub seriesPack: bool,
-}
-
-pub(crate) const SERIES_PACK: SeriesPack = SeriesPack { seriesPack: true };
+//
+// #[derive(Debug, Serialize)]
+// pub(crate) struct StudyDataMeta<'a> {
+//     PatientID: &'a str,
+//     StudyDescription: &'a str,
+//     StudyDate: &'a str,
+//     StudyInstanceUID: &'a str,
+//     PerformedStationAETitle: &'a str,
+// }
+//
+// impl<'a> StudyDataMeta<'a> {
+//     pub fn new(
+//         d: &'a DefaultDicomObject,
+//         e: &'a CommonElements,
+//     ) -> Result<Self, DicomTagReadError> {
+//         let data = Self {
+//             PatientID: e.PatientID,
+//             StudyDescription: e.StudyDescription,
+//             StudyDate: e.StudyDate,
+//             StudyInstanceUID: &e.StudyInstanceUID,
+//             PerformedStationAETitle: tt(d, tags::PERFORMED_STATION_AE_TITLE).unwrap_or(""),
+//         };
+//         Ok(data)
+//     }
+// }
+//
+// #[derive(Debug, Serialize)]
+// pub(crate) struct StudyDataSeriesMeta<'a> {
+//     SeriesInstanceUID: String,
+//     SeriesBaseDir: String,
+//     DICOM: HashMap<String, ValueAndLabel<'a>>,
+// }
+//
+// impl<'a> StudyDataSeriesMeta<'a> {
+//     pub fn new(
+//         SeriesInstanceUID: String,
+//         SeriesBaseDir: String,
+//         dcm: &'a DefaultDicomObject,
+//     ) -> Result<StudyDataSeriesMeta, CastValueError> {
+//         let DICOM = dcm
+//             .iter()
+//             .map(ValueAndLabel::try_from)
+//             .filter_map(|r| r.ok())
+//             .map(|v| (v.label.to_string(), v))
+//             .collect::<HashMap<String, ValueAndLabel>>();
+//         Ok(Self {
+//             SeriesInstanceUID,
+//             SeriesBaseDir,
+//             DICOM,
+//         })
+//     }
+// }
+//
+// impl TryFrom<&InMemElement> for ValueAndLabel<'_> {
+//     type Error = DicomElementSerializationError;
+//     fn try_from(ele: &InMemElement) -> Result<Self, Self::Error> {
+//         let tag = ele.tag();
+//         if tag == tags::PIXEL_DATA {
+//             return Err(DicomElementSerializationError::Excluded(tag));
+//         }
+//         let label =
+//             name_of(tag).ok_or_else(|| DicomElementSerializationError::UnknownTagError(tag))?;
+//         if matches!(ele.value(), Value::PixelSequence { .. }) {
+//             return Err(DicomElementSerializationError::Excluded(tag));
+//         }
+//
+//         let value = if INTEGER_VR.contains(&ele.vr()) {
+//             // e.g. AcquisitionMatrix
+//             serialize_loint(ele)
+//         } else if ele.vr() == VR::DS {
+//             // e.g. PixelSpacing, ImageOrientationPatient
+//             serialize_lonum(ele)
+//         } else {
+//             serialize_lostr(ele)
+//         }?;
+//         Ok(Self { label, value })
+//     }
+// }
+//
+// const INTEGER_VR: [VR; 3] = [VR::US, VR::UL, VR::UV];
+//
+// fn serialize_loint(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
+//     if let Ok(v) = ele.to_multi_int::<i64>() {
+//         let s = serialize_first_or_as_list(v)?;
+//         Ok(s)
+//     } else {
+//         let s = serialize_lostr(ele)?;
+//         eprintln!("WARNING: Could not serialize {} as list of int", &s);
+//         Ok(s)
+//     }
+// }
+//
+// fn serialize_lonum(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
+//     if let Ok(v) = ele.to_multi_float64() {
+//         let s = serialize_first_or_as_list(v)?;
+//         Ok(s)
+//     } else {
+//         let s = serialize_lostr(ele)?;
+//         eprintln!("WARNING: Could not serialize {} as list of float", &s);
+//         Ok(s)
+//     }
+// }
+//
+// fn serialize_lostr(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
+//     let mut values = ele.to_multi_str()?.to_vec();
+//     let value = if values.len() == 1 {
+//         values.swap_remove(0)
+//     } else {
+//         serde_json::to_string(&values)?
+//     };
+//     Ok(value)
+// }
+//
+// fn serialize_first_or_as_list<T: Serialize>(v: Vec<T>) -> Result<String, serde_json::Error> {
+//     if v.len() == 1 {
+//         serde_json::to_string(&v[0])
+//     } else {
+//         serde_json::to_string(&v)
+//     }
+// }
+//
+// #[derive(Debug, Serialize)]
+// struct ValueAndLabel<'a> {
+//     value: String,
+//     label: &'a str,
+// }
+//
+// #[derive(Debug, Serialize)]
+// pub(crate) struct SeriesDataMeta<'a> {
+//     PatientID: &'a str,
+//     StudyInstanceUID: &'a str,
+//     SeriesInstanceUID: &'a str,
+//     SeriesDescription: &'a str,
+//     SeriesNumber: u32,
+//     SeriesDate: &'a str,
+//     Modality: &'a str,
+// }
+//
+// impl<'a> SeriesDataMeta<'a> {
+//     pub fn new(
+//         d: &'a DefaultDicomObject,
+//         e: &'a CommonElements,
+//     ) -> Result<Self, DicomTagReadError> {
+//         let data = Self {
+//             PatientID: e.PatientID,
+//             StudyInstanceUID: &e.StudyInstanceUID,
+//             SeriesInstanceUID: &e.SeriesInstanceUID,
+//             SeriesDescription: e.SeriesDescription,
+//             SeriesNumber: e.SeriesNumber,
+//             SeriesDate: e.StudyDate,
+//             Modality: tt(d, tags::MODALITY)?,
+//         };
+//         Ok(data)
+//     }
+// }
+//
+// #[derive(Debug, Serialize)]
+// pub(crate) struct InstanceData<'a> {
+//     PatientID: &'a str,
+//     StudyInstanceUID: &'a str,
+//     SeriesInstanceUID: &'a str,
+//     SeriesDescription: &'a str,
+//     SeriesNumber: u32,
+//     SeriesDate: &'a str,
+//     Modality: &'a str,
+//     outputFile: &'a str,
+//     // TODO we don't include imageObj because I don't think it's used anywhwere.
+//     // Trying to get this information is annoying.
+//     imageObj: HashMap<String, FileStat>,
+// }
+//
+// impl<'a> InstanceData<'a> {
+//     pub fn new(
+//         d: &'a DefaultDicomObject,
+//         e: &'a CommonElements,
+//         outputFile: &'a str,
+//         FSlocation: String,
+//     ) -> Result<Self, DicomTagReadError> {
+//         let imageObj = [(outputFile.to_string(), FileStat { FSlocation })]
+//             .into_iter()
+//             .collect();
+//         let data = Self {
+//             PatientID: e.PatientID,
+//             StudyInstanceUID: tt(d, tags::STUDY_INSTANCE_UID)?,
+//             SeriesInstanceUID: tt(d, tags::SERIES_INSTANCE_UID)?,
+//             SeriesDescription: tt(d, tags::SERIES_DESCRIPTION)?,
+//             SeriesNumber: tt(d, tags::SERIES_NUMBER)?.parse()?,
+//             SeriesDate: tt(d, tags::SERIES_DATE)?,
+//             Modality: tt(d, tags::MODALITY)?,
+//             outputFile,
+//             imageObj,
+//         };
+//         Ok(data)
+//     }
+// }
+//
+// /// File's stat metadata.
+// /// Not complete.
+// /// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/smdb.py#L1306-L1317
+// #[derive(Debug, Serialize)]
+// struct FileStat {
+//     /// Important! Checked by smdb.py to count how many files are packed so far.
+//     FSlocation: String,
+// }
+//
+// #[derive(Debug, Serialize)]
+// pub(crate) struct SeriesPack {
+//     pub seriesPack: bool,
+// }
+//
+// pub(crate) const SERIES_PACK: SeriesPack = SeriesPack { seriesPack: true };

--- a/src/log_models.rs
+++ b/src/log_models.rs
@@ -1,13 +1,7 @@
 //! Models of what gets written to `/home/dicom/log`.
 #![allow(non_snake_case)]
-use crate::dicom_data::{name_of, CommonElements, TagExtractor};
-use crate::errors::ElementSerializationError;
-use dicom::core::header::Header;
-use dicom::core::value::{DataSetSequence, DicomValueType, Value, ValueType};
-use dicom::core::PrimitiveValue;
+use crate::dicom_data::{CommonElements, TagExtractor};
 use dicom::dictionary_std::tags;
-use dicom::object::mem::InMemElement;
-use dicom::object::{DefaultDicomObject, InMemDicomObject};
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -37,156 +31,104 @@ impl<'a> PatientData<'a> {
         }
     }
 }
-//
-// #[derive(Debug, Serialize)]
-// pub(crate) struct StudyDataMeta<'a> {
-//     PatientID: &'a str,
-//     StudyDescription: &'a str,
-//     StudyDate: &'a str,
-//     StudyInstanceUID: &'a str,
-//     PerformedStationAETitle: &'a str,
-// }
-//
-// impl<'a> StudyDataMeta<'a> {
-//     pub fn new(
-//         d: &'a DefaultDicomObject,
-//         e: &'a CommonElements,
-//     ) -> Result<Self, DicomTagReadError> {
-//         let data = Self {
-//             PatientID: e.PatientID,
-//             StudyDescription: e.StudyDescription,
-//             StudyDate: e.StudyDate,
-//             StudyInstanceUID: &e.StudyInstanceUID,
-//             PerformedStationAETitle: tt(d, tags::PERFORMED_STATION_AE_TITLE).unwrap_or(""),
-//         };
-//         Ok(data)
-//     }
-// }
-//
 
-// fn serialize_loint(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-//     if let Ok(v) = ele.to_multi_int::<i64>() {
-//         let s = serialize_first_or_as_list(v)?;
-//         Ok(s)
-//     } else {
-//         let s = serialize_lostr(ele)?;
-//         eprintln!("WARNING: Could not serialize {} as list of int", &s);
-//         Ok(s)
-//     }
-// }
-//
-// fn serialize_lonum(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-//     if let Ok(v) = ele.to_multi_float64() {
-//         let s = serialize_first_or_as_list(v)?;
-//         Ok(s)
-//     } else {
-//         let s = serialize_lostr(ele)?;
-//         eprintln!("WARNING: Could not serialize {} as list of float", &s);
-//         Ok(s)
-//     }
-// }
-//
-// fn serialize_lostr(ele: &InMemElement) -> Result<String, DicomElementSerializationError> {
-//     let mut values = ele.to_multi_str()?.to_vec();
-//     let value = if values.len() == 1 {
-//         values.swap_remove(0)
-//     } else {
-//         serde_json::to_string(&values)?
-//     };
-//     Ok(value)
-// }
-//
-// fn serialize_first_or_as_list<T: Serialize>(v: Vec<T>) -> Result<String, serde_json::Error> {
-//     if v.len() == 1 {
-//         serde_json::to_string(&v[0])
-//     } else {
-//         serde_json::to_string(&v)
-//     }
-// }
-//
+#[derive(Debug, Serialize)]
+pub(crate) struct StudyDataMeta<'a> {
+    PatientID: &'a str,
+    StudyDescription: &'a str,
+    StudyDate: &'a str,
+    StudyInstanceUID: &'a str,
+    PerformedStationAETitle: Cow<'a, str>,
+}
 
-//
-// #[derive(Debug, Serialize)]
-// pub(crate) struct SeriesDataMeta<'a> {
-//     PatientID: &'a str,
-//     StudyInstanceUID: &'a str,
-//     SeriesInstanceUID: &'a str,
-//     SeriesDescription: &'a str,
-//     SeriesNumber: u32,
-//     SeriesDate: &'a str,
-//     Modality: &'a str,
-// }
-//
-// impl<'a> SeriesDataMeta<'a> {
-//     pub fn new(
-//         d: &'a DefaultDicomObject,
-//         e: &'a CommonElements,
-//     ) -> Result<Self, DicomTagReadError> {
-//         let data = Self {
-//             PatientID: e.PatientID,
-//             StudyInstanceUID: &e.StudyInstanceUID,
-//             SeriesInstanceUID: &e.SeriesInstanceUID,
-//             SeriesDescription: e.SeriesDescription,
-//             SeriesNumber: e.SeriesNumber,
-//             SeriesDate: e.StudyDate,
-//             Modality: tt(d, tags::MODALITY)?,
-//         };
-//         Ok(data)
-//     }
-// }
-//
-// #[derive(Debug, Serialize)]
-// pub(crate) struct InstanceData<'a> {
-//     PatientID: &'a str,
-//     StudyInstanceUID: &'a str,
-//     SeriesInstanceUID: &'a str,
-//     SeriesDescription: &'a str,
-//     SeriesNumber: u32,
-//     SeriesDate: &'a str,
-//     Modality: &'a str,
-//     outputFile: &'a str,
-//     // TODO we don't include imageObj because I don't think it's used anywhwere.
-//     // Trying to get this information is annoying.
-//     imageObj: HashMap<String, FileStat>,
-// }
-//
-// impl<'a> InstanceData<'a> {
-//     pub fn new(
-//         d: &'a DefaultDicomObject,
-//         e: &'a CommonElements,
-//         outputFile: &'a str,
-//         FSlocation: String,
-//     ) -> Result<Self, DicomTagReadError> {
-//         let imageObj = [(outputFile.to_string(), FileStat { FSlocation })]
-//             .into_iter()
-//             .collect();
-//         let data = Self {
-//             PatientID: e.PatientID,
-//             StudyInstanceUID: tt(d, tags::STUDY_INSTANCE_UID)?,
-//             SeriesInstanceUID: tt(d, tags::SERIES_INSTANCE_UID)?,
-//             SeriesDescription: tt(d, tags::SERIES_DESCRIPTION)?,
-//             SeriesNumber: tt(d, tags::SERIES_NUMBER)?.parse()?,
-//             SeriesDate: tt(d, tags::SERIES_DATE)?,
-//             Modality: tt(d, tags::MODALITY)?,
-//             outputFile,
-//             imageObj,
-//         };
-//         Ok(data)
-//     }
-// }
-//
-// /// File's stat metadata.
-// /// Not complete.
-// /// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/smdb.py#L1306-L1317
-// #[derive(Debug, Serialize)]
-// struct FileStat {
-//     /// Important! Checked by smdb.py to count how many files are packed so far.
-//     FSlocation: String,
-// }
-//
-// #[derive(Debug, Serialize)]
-// pub(crate) struct SeriesPack {
-//     pub seriesPack: bool,
-// }
-//
-// pub(crate) const SERIES_PACK: SeriesPack = SeriesPack { seriesPack: true };
+impl<'a> StudyDataMeta<'a> {
+    pub fn new(d: &'a TagExtractor, e: &'a CommonElements) -> Self {
+        Self {
+            PatientID: e.PatientID,
+            StudyDescription: e.StudyDescription,
+            StudyDate: e.StudyDate,
+            StudyInstanceUID: &e.StudyInstanceUID,
+            PerformedStationAETitle: d.get(tags::PERFORMED_STATION_AE_TITLE),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SeriesDataMeta<'a> {
+    PatientID: &'a str,
+    StudyInstanceUID: &'a str,
+    SeriesInstanceUID: &'a str,
+    SeriesDescription: &'a str,
+    SeriesNumber: i32,
+    SeriesDate: &'a str,
+    Modality: Cow<'a, str>,
+}
+
+impl<'a> SeriesDataMeta<'a> {
+    pub fn new(d: &'a TagExtractor, e: &'a CommonElements) -> Self {
+        Self {
+            PatientID: e.PatientID,
+            StudyInstanceUID: &e.StudyInstanceUID,
+            SeriesInstanceUID: &e.SeriesInstanceUID,
+            SeriesDescription: e.SeriesDescription,
+            SeriesNumber: e.SeriesNumber,
+            SeriesDate: e.StudyDate,
+            Modality: d.get(tags::MODALITY),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct InstanceData<'a> {
+    PatientID: &'a str,
+    StudyInstanceUID: &'a str,
+    SeriesInstanceUID: &'a str,
+    SeriesDescription: Cow<'a, str>,
+    SeriesNumber: u32,
+    SeriesDate: Cow<'a, str>,
+    Modality: Cow<'a, str>,
+    outputFile: &'a str,
+    // TODO we don't include imageObj because I don't think it's used anywhwere.
+    // Trying to get this information is annoying.
+    imageObj: HashMap<&'a str, FileStat<'a>>,
+}
+
+impl<'a> InstanceData<'a> {
+    pub fn new(
+        d: &'a TagExtractor,
+        e: &'a CommonElements,
+        outputFile: &'a str,
+        FSlocation: &'a str,
+    ) -> Self {
+        let imageObj = [(outputFile, FileStat { FSlocation })]
+            .into_iter()
+            .collect();
+        Self {
+            PatientID: e.PatientID,
+            StudyInstanceUID: &e.StudyInstanceUID,
+            SeriesInstanceUID: &e.SeriesInstanceUID,
+            SeriesDescription: d.get(tags::SERIES_DESCRIPTION),
+            SeriesNumber: d.get(tags::SERIES_NUMBER).parse().unwrap(), // FIXME
+            SeriesDate: d.get(tags::SERIES_DATE),
+            Modality: d.get(tags::MODALITY),
+            outputFile,
+            imageObj,
+        }
+    }
+}
+
+/// File's stat metadata.
+/// Not complete.
+/// https://github.com/FNNDSC/pypx/blob/7619c15f4d2303d6d5ca7c255d81d06c7ab8682b/pypx/smdb.py#L1306-L1317
+#[derive(Debug, Serialize)]
+struct FileStat<'a> {
+    /// Important! Checked by smdb.py to count how many files are packed so far.
+    FSlocation: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SeriesPack {
+    pub seriesPack: bool,
+}
+
+pub(crate) const SERIES_PACK: SeriesPack = SeriesPack { seriesPack: true };

--- a/src/log_write.rs
+++ b/src/log_write.rs
@@ -2,7 +2,7 @@ use crate::log_models::*;
 use crate::pack_path::PypxPath;
 use camino::Utf8Path;
 
-use crate::dicom_data::{CommonElements, DicomTagError, TagExtractor};
+use crate::dicom_data::{CommonElements, DicomTagAndError, DicomTagError, TagExtractor};
 use dicom::object::{DefaultDicomObject, Tag};
 use hashbrown::HashMap;
 use serde::de::DeserializeOwned;
@@ -19,7 +19,7 @@ pub(crate) fn write_logs(
     common: &CommonElements,
     unpack: &PypxPath,
     log_dir: &Utf8Path,
-) -> anyhow::Result<HashMap<Tag, DicomTagError>> {
+) -> anyhow::Result<Vec<DicomTagAndError>> {
     let d = TagExtractor::new(dcm);
     let patient_data_dir = log_dir.join("patientData");
     let series_data_dir = log_dir.join("seriesData");

--- a/src/log_write.rs
+++ b/src/log_write.rs
@@ -1,8 +1,9 @@
 use crate::log_models::*;
-use crate::pack_path::{PypxPath, PypxPathElements};
+use crate::pack_path::PypxPath;
 use camino::Utf8Path;
 
-use dicom::object::DefaultDicomObject;
+use crate::dicom_data::{CommonElements, DicomTagError, TagExtractor};
+use dicom::object::{DefaultDicomObject, Tag};
 use hashbrown::HashMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -15,73 +16,74 @@ use std::path::PathBuf;
 #[allow(non_snake_case)]
 pub(crate) fn write_logs(
     dcm: &DefaultDicomObject,
-    elements: &PypxPathElements,
+    common: &CommonElements,
     unpack: &PypxPath,
     log_dir: &Utf8Path,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<HashMap<Tag, DicomTagError>> {
+    let d = TagExtractor::new(dcm);
     let patient_data_dir = log_dir.join("patientData");
     let series_data_dir = log_dir.join("seriesData");
     let study_data_dir = log_dir.join("studyData");
 
     // write stuff to patientData/MRN.json
     let patient_data_fname = patient_data_dir
-        .join(elements.PatientID)
+        .join(common.PatientID)
         .with_extension("json");
     let mut patient_data: HashMap<String, PatientData> =
         load_json_carelessly(&patient_data_fname).unwrap_or_else(|| HashMap::with_capacity(1));
     patient_data
-        .entry_ref(elements.PatientID)
-        .or_insert_with(|| PatientData::new(dcm, elements).unwrap())
+        .entry_ref(common.PatientID)
+        .or_insert_with(|| PatientData::new(&d, common))
         .StudyList
-        .insert(elements.StudyInstanceUID.to_string());
+        .insert(common.StudyInstanceUID.to_string());
     write_json(patient_data, patient_data_fname)?;
+    //
+    // // write stuff to studyData/X.X.X.XXXXX-series/Y.Y.Y.YYYYY-meta.json
+    // let study_series_meta_dir =
+    //     study_data_dir.join(format!("{}-series", &elements.StudyInstanceUID));
+    // fs_err::create_dir_all(&study_series_meta_dir)?;
+    // let study_series_meta_fname =
+    //     study_series_meta_dir.join(format!("{}-meta.json", &elements.SeriesInstanceUID));
+    // if !study_series_meta_fname.is_file() {
+    //     let study_series_meta = StudyDataSeriesMeta::new(
+    //         elements.SeriesInstanceUID.to_string(),
+    //         unpack.dir.to_string(),
+    //         dcm,
+    //     )?;
+    //     let data: HashMap<_, _> = [(&elements.StudyInstanceUID, study_series_meta)].into();
+    //     write_json(data, study_series_meta_fname)?;
+    // }
+    //
+    // // write stuff to studyData/X.X.X.XXXXX-meta.json
+    // let study_meta_fname = study_data_dir.join(format!("{}-meta.json", &elements.StudyInstanceUID));
+    // if !study_meta_fname.is_file() {
+    //     let study_meta_data = StudyDataMeta::new(dcm, elements)?;
+    //     write_json(study_meta_data, study_meta_fname)?;
+    // }
+    //
+    // // write stuff to seriesData/Y.Y.Y.YYYYY-meta.json
+    // let series_meta_fname =
+    //     series_data_dir.join(format!("{}-meta.json", &elements.SeriesInstanceUID));
+    // if !series_meta_fname.is_file() {
+    //     let series_meta_data = SeriesDataMeta::new(dcm, elements)?;
+    //     write_json(series_meta_data, series_meta_fname)?;
+    // }
+    //
+    // // write stuff to seriesData/Y.Y.Y.YYYYY-pack.json
+    // let pack_fname = series_data_dir.join(format!("{}-pack.json", &elements.SeriesInstanceUID));
+    // if !pack_fname.is_file() {
+    //     write_json(SERIES_PACK, pack_fname)?;
+    // }
+    //
+    // // write stuff to seriesData/Y.Y.Y.YYYYY-img/Z.Z.Z.ZZZZZ.dcm.json
+    // let img_data_dir = series_data_dir.join(format!("{}-img", &elements.SeriesInstanceUID));
+    // fs_err::create_dir_all(&img_data_dir)?;
+    // let img_data_fname = img_data_dir.join(format!("{}.json", unpack.fname));
+    // let img_data = InstanceData::new(dcm, elements, &unpack.fname, unpack.path.to_string())?;
+    // let data: HashMap<_, _> = [(&elements.SeriesInstanceUID, img_data)].into();
+    // write_json(data, img_data_fname)?;
 
-    // write stuff to studyData/X.X.X.XXXXX-series/Y.Y.Y.YYYYY-meta.json
-    let study_series_meta_dir =
-        study_data_dir.join(format!("{}-series", &elements.StudyInstanceUID));
-    fs_err::create_dir_all(&study_series_meta_dir)?;
-    let study_series_meta_fname =
-        study_series_meta_dir.join(format!("{}-meta.json", &elements.SeriesInstanceUID));
-    if !study_series_meta_fname.is_file() {
-        let study_series_meta = StudyDataSeriesMeta::new(
-            elements.SeriesInstanceUID.to_string(),
-            unpack.dir.to_string(),
-            dcm,
-        )?;
-        let data: HashMap<_, _> = [(&elements.StudyInstanceUID, study_series_meta)].into();
-        write_json(data, study_series_meta_fname)?;
-    }
-
-    // write stuff to studyData/X.X.X.XXXXX-meta.json
-    let study_meta_fname = study_data_dir.join(format!("{}-meta.json", &elements.StudyInstanceUID));
-    if !study_meta_fname.is_file() {
-        let study_meta_data = StudyDataMeta::new(dcm, elements)?;
-        write_json(study_meta_data, study_meta_fname)?;
-    }
-
-    // write stuff to seriesData/Y.Y.Y.YYYYY-meta.json
-    let series_meta_fname =
-        series_data_dir.join(format!("{}-meta.json", &elements.SeriesInstanceUID));
-    if !series_meta_fname.is_file() {
-        let series_meta_data = SeriesDataMeta::new(dcm, elements)?;
-        write_json(series_meta_data, series_meta_fname)?;
-    }
-
-    // write stuff to seriesData/Y.Y.Y.YYYYY-pack.json
-    let pack_fname = series_data_dir.join(format!("{}-pack.json", &elements.SeriesInstanceUID));
-    if !pack_fname.is_file() {
-        write_json(SERIES_PACK, pack_fname)?;
-    }
-
-    // write stuff to seriesData/Y.Y.Y.YYYYY-img/Z.Z.Z.ZZZZZ.dcm.json
-    let img_data_dir = series_data_dir.join(format!("{}-img", &elements.SeriesInstanceUID));
-    fs_err::create_dir_all(&img_data_dir)?;
-    let img_data_fname = img_data_dir.join(format!("{}.json", unpack.fname));
-    let img_data = InstanceData::new(dcm, elements, &unpack.fname, unpack.path.to_string())?;
-    let data: HashMap<_, _> = [(&elements.SeriesInstanceUID, img_data)].into();
-    write_json(data, img_data_fname)?;
-
-    Ok(())
+    Ok(d.errors.into_inner())
 }
 
 /// Read and deserialize a JSON file. In case of any error, return `None`.

--- a/src/log_write.rs
+++ b/src/log_write.rs
@@ -46,39 +46,39 @@ pub(crate) fn write_logs(
         study_series_meta_dir.join(format!("{}-meta.json", &common.SeriesInstanceUID));
     if !study_series_meta_fname.is_file() {
         let study_series_meta =
-            StudyDataSeriesMeta::new(&common.SeriesInstanceUID, &unpack.dir.as_str(), dcm);
+            StudyDataSeriesMeta::new(&common.SeriesInstanceUID, unpack.dir.as_str(), dcm);
         let data: HashMap<_, _> = [(&common.StudyInstanceUID, study_series_meta)].into();
         write_json(data, study_series_meta_fname)?;
     }
-    //
-    // // write stuff to studyData/X.X.X.XXXXX-meta.json
-    // let study_meta_fname = study_data_dir.join(format!("{}-meta.json", &elements.StudyInstanceUID));
-    // if !study_meta_fname.is_file() {
-    //     let study_meta_data = StudyDataMeta::new(dcm, elements)?;
-    //     write_json(study_meta_data, study_meta_fname)?;
-    // }
-    //
-    // // write stuff to seriesData/Y.Y.Y.YYYYY-meta.json
-    // let series_meta_fname =
-    //     series_data_dir.join(format!("{}-meta.json", &elements.SeriesInstanceUID));
-    // if !series_meta_fname.is_file() {
-    //     let series_meta_data = SeriesDataMeta::new(dcm, elements)?;
-    //     write_json(series_meta_data, series_meta_fname)?;
-    // }
-    //
-    // // write stuff to seriesData/Y.Y.Y.YYYYY-pack.json
-    // let pack_fname = series_data_dir.join(format!("{}-pack.json", &elements.SeriesInstanceUID));
-    // if !pack_fname.is_file() {
-    //     write_json(SERIES_PACK, pack_fname)?;
-    // }
-    //
-    // // write stuff to seriesData/Y.Y.Y.YYYYY-img/Z.Z.Z.ZZZZZ.dcm.json
-    // let img_data_dir = series_data_dir.join(format!("{}-img", &elements.SeriesInstanceUID));
-    // fs_err::create_dir_all(&img_data_dir)?;
-    // let img_data_fname = img_data_dir.join(format!("{}.json", unpack.fname));
-    // let img_data = InstanceData::new(dcm, elements, &unpack.fname, unpack.path.to_string())?;
-    // let data: HashMap<_, _> = [(&elements.SeriesInstanceUID, img_data)].into();
-    // write_json(data, img_data_fname)?;
+
+    // write stuff to studyData/X.X.X.XXXXX-meta.json
+    let study_meta_fname = study_data_dir.join(format!("{}-meta.json", &common.StudyInstanceUID));
+    if !study_meta_fname.is_file() {
+        let study_meta_data = StudyDataMeta::new(&dcmtags, common);
+        write_json(study_meta_data, study_meta_fname)?;
+    }
+
+    // write stuff to seriesData/Y.Y.Y.YYYYY-meta.json
+    let series_meta_fname =
+        series_data_dir.join(format!("{}-meta.json", &common.SeriesInstanceUID));
+    if !series_meta_fname.is_file() {
+        let series_meta_data = SeriesDataMeta::new(&dcmtags, common);
+        write_json(series_meta_data, series_meta_fname)?;
+    }
+
+    // write stuff to seriesData/Y.Y.Y.YYYYY-img/Z.Z.Z.ZZZZZ.dcm.json
+    let img_data_dir = series_data_dir.join(format!("{}-img", &common.SeriesInstanceUID));
+    fs_err::create_dir_all(&img_data_dir)?;
+    let img_data_fname = img_data_dir.join(format!("{}.json", unpack.fname));
+    let img_data = InstanceData::new(&dcmtags, common, &unpack.fname, unpack.path.as_str());
+    let data: HashMap<_, _> = [(&common.SeriesInstanceUID, img_data)].into();
+    write_json(data, img_data_fname)?;
+
+    // write stuff to seriesData/Y.Y.Y.YYYYY-pack.json
+    let pack_fname = series_data_dir.join(format!("{}-pack.json", &common.SeriesInstanceUID));
+    if !pack_fname.is_file() {
+        write_json(SERIES_PACK, pack_fname)?;
+    }
 
     Ok(dcmtags.errors.into_inner())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-mod ndjson_log;
-
-use crate::ndjson_log::json_message;
 use camino::Utf8PathBuf;
 use clap::Parser;
-use rx_repack::repack;
+use rx_repack::{json_message, repack};
 
 #[derive(clap::Parser)]
 #[clap(
@@ -65,7 +62,7 @@ fn main() -> anyhow::Result<()> {
         // https://12factor.net/logs
         // NDJson is a best practice for logging:
         // http://ndjson.org/
-        println!("{}", json_message(&dicom_file, dst)?);
+        println!("{}", json_message(&dicom_file, &dst)?);
     }
 
     anyhow::Ok(())

--- a/src/ndjson_log.rs
+++ b/src/ndjson_log.rs
@@ -1,6 +1,6 @@
 use crate::dicom_data::{name_of, DicomTagAndError};
 use crate::repack::RepackOutcome;
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use serde::Serialize;
 use std::os::unix::fs::MetadataExt;
 

--- a/src/ndjson_log.rs
+++ b/src/ndjson_log.rs
@@ -1,25 +1,31 @@
-use crate::dicom_data::{name_of, DicomTagAndError, DicomTagError};
+use crate::dicom_data::{name_of, DicomTagAndError};
+use crate::repack::RepackOutcome;
 use camino::{Utf8Path, Utf8PathBuf};
-use dicom::object::Tag;
-use hashbrown::HashMap;
 use serde::Serialize;
 use std::os::unix::fs::MetadataExt;
 
 /// Produce a JSON string which describes the outcome of `rx-repack`.
 pub fn json_message(
     src: &Utf8Path,
-    result: &anyhow::Result<(Utf8PathBuf, Vec<DicomTagAndError>)>,
+    result: &anyhow::Result<RepackOutcome>,
 ) -> anyhow::Result<String> {
     let msg = Message::new(src, result);
     serde_json::to_string(&msg).map_err(anyhow::Error::from)
 }
 
+#[allow(non_snake_case)]
 #[derive(Serialize, Debug)]
 struct Message<'a> {
     src: &'a Utf8Path,
     dst: Option<&'a Utf8Path>,
     #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    PatientID: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    SeriesInstanceUID: Option<&'a str>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -44,21 +50,24 @@ impl From<&DicomTagAndError> for DicomTagNameAndError {
 }
 
 impl<'a> Message<'a> {
-    fn new(
-        src: &'a Utf8Path,
-        result: &'a anyhow::Result<(Utf8PathBuf, Vec<DicomTagAndError>)>,
-    ) -> Self {
+    fn new(src: &'a Utf8Path, result: &'a anyhow::Result<RepackOutcome>) -> Self {
         match result {
-            Ok((dst, missing)) => {
-                let (size, error) = fs_err::metadata(dst)
+            Ok(outcome) => {
+                let (size, error) = fs_err::metadata(&outcome.dst)
                     .map(|metadata| (Some(metadata.size()), None))
                     .unwrap_or_else(|error| (None, Some(error.to_string())));
                 Self {
                     src,
-                    dst: Some(dst),
+                    dst: Some(&outcome.dst),
                     size,
                     error,
-                    missing: missing.iter().map(DicomTagNameAndError::from).collect(),
+                    missing: outcome
+                        .missing
+                        .iter()
+                        .map(DicomTagNameAndError::from)
+                        .collect(),
+                    PatientID: Some(&outcome.PatientID),
+                    SeriesInstanceUID: Some(&outcome.SeriesInstanceUID),
                 }
             }
             Err(e) => Self {
@@ -67,6 +76,8 @@ impl<'a> Message<'a> {
                 size: None,
                 error: Some(e.to_string()),
                 missing: Vec::new(),
+                PatientID: None,
+                SeriesInstanceUID: None,
             },
         }
     }

--- a/src/ndjson_log.rs
+++ b/src/ndjson_log.rs
@@ -1,4 +1,4 @@
-use crate::dicom_data::DicomTagError;
+use crate::dicom_data::{name_of, DicomTagAndError, DicomTagError};
 use camino::{Utf8Path, Utf8PathBuf};
 use dicom::object::Tag;
 use hashbrown::HashMap;
@@ -8,7 +8,7 @@ use std::os::unix::fs::MetadataExt;
 /// Produce a JSON string which describes the outcome of `rx-repack`.
 pub fn json_message(
     src: &Utf8Path,
-    result: &anyhow::Result<(Utf8PathBuf, HashMap<Tag, DicomTagError>)>,
+    result: &anyhow::Result<(Utf8PathBuf, Vec<DicomTagAndError>)>,
 ) -> anyhow::Result<String> {
     let msg = Message::new(src, result);
     serde_json::to_string(&msg).map_err(anyhow::Error::from)
@@ -21,33 +21,53 @@ struct Message<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    err: Option<String>,
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    missing: Vec<DicomTagNameAndError>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct DicomTagNameAndError {
+    tag: String,
+    name: Option<&'static str>,
+    error: String,
+}
+
+impl From<&DicomTagAndError> for DicomTagNameAndError {
+    fn from(value: &DicomTagAndError) -> Self {
+        Self {
+            tag: value.tag.to_string(),
+            name: name_of(value.tag),
+            error: value.error.to_string(),
+        }
+    }
 }
 
 impl<'a> Message<'a> {
     fn new(
         src: &'a Utf8Path,
-        result: &'a anyhow::Result<(Utf8PathBuf, HashMap<Tag, DicomTagError>)>,
+        result: &'a anyhow::Result<(Utf8PathBuf, Vec<DicomTagAndError>)>,
     ) -> Self {
-        result
-            .as_ref()
-            .map_err(|e| anyhow::Error::msg(e.to_string())) // FIXME
-            .and_then(|(dst, _warnings)| {
-                fs_err::metadata(dst)
-                    .map(|m| (dst, m.size()))
-                    .map_err(anyhow::Error::from)
-            })
-            .map(|(dst, size)| Self {
-                src,
-                dst: Some(dst),
-                size: Some(size),
-                err: None,
-            })
-            .unwrap_or_else(|e| Self {
+        match result {
+            Ok((dst, missing)) => {
+                let (size, error) = fs_err::metadata(dst)
+                    .map(|metadata| (Some(metadata.size()), None))
+                    .unwrap_or_else(|error| (None, Some(error.to_string())));
+                Self {
+                    src,
+                    dst: Some(dst),
+                    size,
+                    error,
+                    missing: missing.iter().map(DicomTagNameAndError::from).collect(),
+                }
+            }
+            Err(e) => Self {
                 src,
                 dst: None,
                 size: None,
-                err: Some(e.to_string()),
-            })
+                error: Some(e.to_string()),
+                missing: Vec::new(),
+            },
+        }
     }
 }

--- a/src/pack_path.rs
+++ b/src/pack_path.rs
@@ -1,9 +1,7 @@
 //! Functions for deciding where to copy the received DICOM to.
-use crate::errors::DicomTagReadError;
-use crate::helpers::{sanitize, tt, tts};
+use crate::dicom_data::CommonElements;
+use crate::helpers::sanitize;
 use camino::{Utf8Path, Utf8PathBuf};
-use dicom::dictionary_std::tags;
-use dicom::object::DefaultDicomObject;
 
 /// Destination directory and file name for the DICOM file.
 pub(crate) struct PypxPath {
@@ -15,7 +13,7 @@ pub(crate) struct PypxPath {
 impl PypxPath {
     /// Equivalent Python implementation `pypx.repack.Process.packPath_resolve`:
     /// https://github.com/FNNDSC/pypx/blob/d4791598f65b257cbf6b17d6b5b05db777844db4/pypx/repack.py#L412-L459
-    pub fn new(dcm: &PypxPathElements, data_dir: &Utf8Path) -> Self {
+    pub fn new(dcm: &CommonElements, data_dir: &Utf8Path) -> Self {
         let root_dir = sanitize(format!(
             "{}-{}-{}",
             dcm.PatientID, dcm.PatientName, dcm.PatientBirthDate
@@ -41,49 +39,5 @@ impl PypxPath {
             dir: pack_dir,
             path,
         }
-    }
-}
-
-/// DICOM elements which a [PypxPath] is comprised of.
-#[allow(non_snake_case)]
-pub(crate) struct PypxPathElements<'a> {
-    // these are all part of the path name.
-    pub InstanceNumber: &'a str,
-    pub SOPInstanceUID: &'a str,
-    pub PatientID: &'a str,
-    pub PatientName: &'a str,
-    pub PatientBirthDate: &'a str,
-    pub StudyDescription: &'a str,
-    pub AccessionNumnber: &'a str,
-    pub StudyDate: &'a str,
-    pub SeriesNumber: u32,
-    pub SeriesDescription: &'a str,
-
-    // these are not part of the path name, but used in the log path names.
-    pub StudyInstanceUID: String,
-    pub SeriesInstanceUID: String,
-}
-
-impl<'a> TryFrom<&'a DefaultDicomObject> for PypxPathElements<'a> {
-    type Error = DicomTagReadError;
-    fn try_from(dcm: &'a DefaultDicomObject) -> Result<Self, Self::Error> {
-        // NOTE: the implementation here is optimized based on implementation details of dicom-rs v0.5.4.
-        // - dcm.element(...)?.string() produces a reference to the data w/o cloning nor parsing
-        // - dcm.element is more efficient than dcm.element_by_name, sinnce the latter does a map lookup
-        let data = Self {
-            InstanceNumber: tt(dcm, tags::INSTANCE_NUMBER)?,
-            SOPInstanceUID: tt(dcm, tags::SOP_INSTANCE_UID)?,
-            PatientID: tt(dcm, tags::PATIENT_ID)?,
-            PatientName: tt(dcm, tags::PATIENT_NAME)?,
-            PatientBirthDate: tt(dcm, tags::PATIENT_BIRTH_DATE)?,
-            StudyDescription: tt(dcm, tags::STUDY_DESCRIPTION)?,
-            AccessionNumnber: tt(dcm, tags::ACCESSION_NUMBER)?,
-            StudyDate: tt(dcm, tags::STUDY_DATE)?,
-            SeriesNumber: tt(dcm, tags::SERIES_NUMBER)?.parse()?,
-            SeriesDescription: tt(dcm, tags::SERIES_DESCRIPTION)?,
-            StudyInstanceUID: tts(dcm, tags::STUDY_INSTANCE_UID)?,
-            SeriesInstanceUID: tts(dcm, tags::SERIES_INSTANCE_UID)?,
-        };
-        Ok(data)
     }
 }

--- a/src/repack.rs
+++ b/src/repack.rs
@@ -2,9 +2,7 @@ use crate::log_write::write_logs;
 use crate::pack_path::PypxPath;
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::dicom_data::DicomTagError;
-use dicom::object::Tag;
-use hashbrown::HashMap;
+use crate::dicom_data::DicomTagAndError;
 use std::path::Path;
 
 pub fn repack(
@@ -12,7 +10,7 @@ pub fn repack(
     data_dir: &Utf8Path,
     log_dir: Option<&Utf8Path>,
     cleanup: bool,
-) -> anyhow::Result<(Utf8PathBuf, HashMap<Tag, DicomTagError>)> {
+) -> anyhow::Result<(Utf8PathBuf, Vec<DicomTagAndError>)> {
     let dcm = dicom::object::open_file(dicom_file)?;
     let common = (&dcm).try_into()?;
     let unpack = PypxPath::new(&common, data_dir);
@@ -24,7 +22,7 @@ pub fn repack(
         let warnings = write_logs(&dcm, &common, &unpack, d)?;
         anyhow::Ok((unpack.path, warnings))
     } else {
-        anyhow::Ok((unpack.path, HashMap::new()))
+        anyhow::Ok((unpack.path, Vec::new()))
     }
 }
 

--- a/src/serialize_seriesmeta.rs
+++ b/src/serialize_seriesmeta.rs
@@ -1,0 +1,147 @@
+//! Helpers for serializing the stuff which goes into e.g.
+//! `/home/dicom/log/studyData/1.2.840.113845.11.1000000001785349915.20130308061609.6346698-series/1.3.12.2.1107.5.2.19.45152.2013030808061520200285270.0.0.0-meta.json`
+#![allow(non_snake_case)]
+use crate::dicom_data::name_of;
+use crate::errors::ElementSerializationError;
+use dicom::core::header::Header;
+use dicom::core::value::{DataSetSequence, Value};
+use dicom::core::{PrimitiveValue, VR};
+use dicom::dictionary_std::tags;
+use dicom::object::mem::InMemElement;
+use dicom::object::{DefaultDicomObject, InMemDicomObject};
+use hashbrown::HashMap;
+use itertools::Itertools;
+use serde::Serialize;
+use std::borrow::Cow;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StudyDataSeriesMeta<'a> {
+    SeriesInstanceUID: &'a str,
+    SeriesBaseDir: &'a str,
+    DICOM: HashMap<String, ValueAndLabel<'a>>,
+}
+
+impl<'a> StudyDataSeriesMeta<'a> {
+    pub fn new(
+        SeriesInstanceUID: &'a str,
+        SeriesBaseDir: &'a str,
+        dcm: &'a DefaultDicomObject,
+    ) -> Self {
+        let DICOM = dcm
+            .iter()
+            .filter(|ele| ele.tag() != tags::PIXEL_DATA)
+            .map(ValueAndLabel::try_from)
+            .filter_map(|r| r.ok())
+            .map(|v| (v.label.to_string(), v))
+            .collect::<HashMap<String, ValueAndLabel>>();
+        Self {
+            SeriesInstanceUID,
+            SeriesBaseDir,
+            DICOM,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ValueAndLabel<'a> {
+    value: Cow<'a, str>,
+    label: &'a str,
+}
+
+impl<'a> TryFrom<&'a InMemElement> for ValueAndLabel<'a> {
+    type Error = ElementSerializationError;
+    fn try_from(ele: &'a InMemElement) -> Result<Self, Self::Error> {
+        let tag = ele.tag();
+        let label = name_of(tag).ok_or_else(|| ElementSerializationError::UnknownTagError(tag))?;
+        let value = match ele.value() {
+            Value::Primitive(value) => Ok(serialize_primitive(value, ele.vr())),
+            Value::Sequence(seq) => {
+                // e.g. tags with complex data such as ReferencedImageSequence and RequestAttributesSequence
+                let s = serialize_sequence(seq);
+                Ok(Cow::Owned(s))
+            }
+            Value::PixelSequence(_) => Err(ElementSerializationError::Excluded(tag)),
+        }?;
+        // println!("{} {} {:?} {}", label, ele.vr(), ele.value(), value);
+        Ok(Self { label, value })
+    }
+}
+
+/// Serialize a [PrimitiveValue].
+///
+/// You would think that [PrimitiveValue::to_str] is sufficient, and sometimes it is,
+/// but lists of numbers such as `ImagePositionPatient` are represented as a list of
+/// strings instead of floats. Thus we need to do some custom logic of our own.
+///
+/// See discussion on Github: https://github.com/Enet4/dicom-rs/discussions/401
+fn serialize_primitive(value: &PrimitiveValue, vr: VR) -> Cow<str> {
+    match value {
+        PrimitiveValue::Strs(strs) => {
+            if matches!(vr, VR::IS | VR::SS | VR::DS) {
+                serialize_nums(strs, value)
+            } else if strs.len() > 1 {
+                serde_json::to_string(strs.as_slice())
+                    .map(Cow::Owned)
+                    .unwrap_or_else(|_| value.to_str())
+            } else {
+                value.to_str()
+            }
+        }
+        PrimitiveValue::U8(nums) => serialize_nums(nums, value),
+        PrimitiveValue::I16(nums) => serialize_nums(nums, value),
+        PrimitiveValue::U16(nums) => serialize_nums(nums, value),
+        PrimitiveValue::I32(nums) => serialize_nums(nums, value),
+        PrimitiveValue::U32(nums) => serialize_nums(nums, value),
+        PrimitiveValue::I64(nums) => serialize_nums(nums, value),
+        PrimitiveValue::U64(nums) => serialize_nums(nums, value),
+        PrimitiveValue::F32(nums) => serialize_nums(nums, value),
+        PrimitiveValue::F64(nums) => serialize_nums(nums, value),
+        _ => value.to_str(),
+    }
+}
+
+/// Serialize a list of numbers to a JSON string.
+fn serialize_nums<'a, D: std::fmt::Display>(
+    strs: &'a dicom::core::value::C<D>,
+    value: &'a PrimitiveValue,
+) -> Cow<'a, str> {
+    if strs.len() == 1 {
+        return value.to_str();
+    }
+    let s = format!("[{}]", strs.iter().join(", "));
+    Cow::Owned(s)
+}
+
+/// Serializer for [Value::Sequence].
+fn serialize_sequence(seq: &DataSetSequence<InMemDicomObject>) -> String {
+    format!(
+        "[{}]",
+        seq.items().iter().flat_map(serialize_subdicom).join("\n")
+    )
+}
+
+/// Serializes a complicated element, e.g. `RequestAttributesSequence` and `ReferencedImageSequence`
+///
+/// Example for `RequestAttributesSequence`
+///
+/// `"[(0040, 0007) Scheduled Procedure Step Descriptio LO: 'MR Brain'\n(0040, 0009) Scheduled Procedure Step ID         SH: '4101374'\n(0040, 1001) Requested Procedure ID              SH: '4101374']"`
+fn serialize_subdicom(dcm: &InMemDicomObject) -> impl Iterator<Item = String> + '_ {
+    dcm.iter().map(serialize_subdicom_element)
+}
+
+fn serialize_subdicom_element(ele: &InMemElement) -> String {
+    let tag = ele.tag();
+
+    // This doesn't perfectly match what px-repack would spit out, because px-repack would give a fully
+    // human-readable name from the "Attribute Name" column of this table:
+    // https://dicom.nema.org/medical/dicom/2020b/output/chtml/part03/sect_C.4.10.html
+    // e.g. "Scheduled Procedure Step Descriptio"
+    let label = name_of(tag).unwrap_or("RX_REPACK_ERROR");
+
+    let vr = ele.vr();
+    let value = ele
+        .to_str()
+        .map(|c| c.to_string())
+        .unwrap_or("RX_REPACK_ERROR".to_string());
+    format!("{tag} {label} {vr}: {value}")
+}


### PR DESCRIPTION
- Missing DICOM tags no longer crashes the program
- JSON logging output is enriched with PatientID, SeriesInstanceUID, and any warnings generated from trying to read missing tags
- Code quality improvements