### PR TITLE
Missing defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "rx-repack"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rx-repack"
 description = "Rust re-write of px-repack"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/dicom_data.rs
+++ b/src/dicom_data.rs
@@ -73,7 +73,9 @@ impl<'a> TagExtractor<'a> {
             .unwrap_or_else(|error| {
                 let e = DicomTagAndError { tag, error };
                 self.errors.borrow_mut().push(e);
-                "".into()
+
+                // https://github.com/FNNDSC/pypx/wiki/How-pypx-handles-missing-elements
+                "Not defined".into()
             })
     }
 

--- a/src/log_models.rs
+++ b/src/log_models.rs
@@ -1,6 +1,6 @@
 //! Models of what gets written to `/home/dicom/log`.
 #![allow(non_snake_case)]
-use crate::dicom_data::{CommonElements, TagExtractor};
+use crate::dicom_data::{CommonElements, NOT_DEFINED, TagExtractor};
 use dicom::dictionary_std::tags;
 use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ impl<'a> PatientData<'a> {
             PatientName,
             PatientAge,
             PatientSex,
-            PatientBirthDate: Cow::Borrowed(e.PatientBirthDate),
+            PatientBirthDate: Cow::Borrowed(e.PatientBirthDate.unwrap_or(NOT_DEFINED)),
             StudyList: HashSet::new(),
         }
     }
@@ -45,8 +45,8 @@ impl<'a> StudyDataMeta<'a> {
     pub fn new(d: &'a TagExtractor, e: &'a CommonElements) -> Self {
         Self {
             PatientID: e.PatientID,
-            StudyDescription: e.StudyDescription,
-            StudyDate: e.StudyDate,
+            StudyDescription: e.StudyDescription.unwrap_or(NOT_DEFINED),
+            StudyDate: e.StudyDate.unwrap_or(NOT_DEFINED),
             StudyInstanceUID: &e.StudyInstanceUID,
             PerformedStationAETitle: d.get(tags::PERFORMED_STATION_AE_TITLE),
         }
@@ -70,9 +70,9 @@ impl<'a> SeriesDataMeta<'a> {
             PatientID: e.PatientID,
             StudyInstanceUID: &e.StudyInstanceUID,
             SeriesInstanceUID: &e.SeriesInstanceUID,
-            SeriesDescription: e.SeriesDescription,
+            SeriesDescription: e.SeriesDescription.unwrap_or(NOT_DEFINED),
             SeriesNumber: e.SeriesNumber,
-            SeriesDate: e.StudyDate,
+            SeriesDate: e.StudyDate.unwrap_or(NOT_DEFINED),
             Modality: d.get(tags::MODALITY),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ struct Cli {
 fn main() -> anyhow::Result<()> {
     let args: Cli = Cli::parse();
     let dicom_file = args.xcrdir.join(&args.xcrfile);
-    let dst = repack(
+    let outcome = repack(
         &dicom_file,
         &args.datadir,
         args.logdir.as_ref().map(|p| p.as_path()),
@@ -62,8 +62,8 @@ fn main() -> anyhow::Result<()> {
         // https://12factor.net/logs
         // NDJson is a best practice for logging:
         // http://ndjson.org/
-        println!("{}", json_message(&dicom_file, &dst)?);
+        println!("{}", json_message(&dicom_file, &outcome)?);
     }
 
-    anyhow::Ok(())
+    outcome.map(|_| ())
 }

--- a/src/pack_path.rs
+++ b/src/pack_path.rs
@@ -13,18 +13,26 @@ pub(crate) struct PypxPath {
 impl PypxPath {
     /// Equivalent Python implementation `pypx.repack.Process.packPath_resolve`:
     /// https://github.com/FNNDSC/pypx/blob/d4791598f65b257cbf6b17d6b5b05db777844db4/pypx/repack.py#L412-L459
+    ///
+    /// Missing DICOM element values are replaced with the name of the DICOM tag.
+    /// See https://github.com/FNNDSC/pypx/wiki/How-pypx-handles-missing-elements
     pub fn new(dcm: &CommonElements, data_dir: &Utf8Path) -> Self {
         let root_dir = sanitize(format!(
             "{}-{}-{}",
-            dcm.PatientID, dcm.PatientName, dcm.PatientBirthDate
+            dcm.PatientID,
+            dcm.PatientName.unwrap_or("PatientName"),
+            dcm.PatientBirthDate.unwrap_or("PatientBirthDate")
         ));
         let study_dir = sanitize(format!(
             "{}-{}-{}",
-            dcm.StudyDescription, dcm.AccessionNumnber, dcm.StudyDate
+            dcm.StudyDescription.unwrap_or("StudyDescription"),
+            dcm.AccessionNumnber,
+            dcm.StudyDate.unwrap_or("StudyDate")
         ));
         let series_dir = sanitize(format!(
             "{:0>5}-{}",
-            dcm.SeriesNumber, dcm.SeriesDescription
+            dcm.SeriesNumber,
+            dcm.SeriesDescription.unwrap_or("SeriesDescription")
         ));
 
         let pack_dir_rel = Utf8PathBuf::from(root_dir).join(study_dir).join(series_dir);


### PR DESCRIPTION
Some of the DICOM tags which are part of the pack path are now allowed to be undefined. Specifically, PatientName, PatientBirthDate, StudyDescription, StudyDate, SeriesDescription may be undefined.

The name of the DICOM tag is used in the pack path. The string "Not defined" is used in JSON data.